### PR TITLE
Add rich image type

### DIFF
--- a/schemaTypes/documents/articleType.ts
+++ b/schemaTypes/documents/articleType.ts
@@ -26,7 +26,11 @@ export const articleType = defineType({
       name: 'content',
       title: 'Content',
       type: 'array',
-      of: [{ type: 'codeBlockList' }, { type: 'textBlockList' }],
+      of: [
+        { type: 'codeBlockList' },
+        { type: 'richImageList' },
+        { type: 'textBlockList' },
+      ],
     }),
   ],
 })

--- a/schemaTypes/index.ts
+++ b/schemaTypes/index.ts
@@ -1,9 +1,7 @@
-import { articleType } from './documents'
-import { codeBlockListType, textBlockListType, textBlockType } from './objects'
+import * as documents from './documents'
+import * as objects from './objects'
 
 export const schemaTypes = [
-  articleType,
-  codeBlockListType,
-  textBlockListType,
-  textBlockType,
+  ...Object.values(documents),
+  ...Object.values(objects),
 ]

--- a/schemaTypes/objects/index.ts
+++ b/schemaTypes/objects/index.ts
@@ -1,3 +1,5 @@
 export { codeBlockListType } from './codeBlockListType'
+export { richImageListType } from './richImageListType'
+export { richImageType } from './richImageType'
 export { textBlockListType } from './textBlockListType'
 export { textBlockType } from './textBlockType'

--- a/schemaTypes/objects/richImageListType.ts
+++ b/schemaTypes/objects/richImageListType.ts
@@ -1,0 +1,29 @@
+import { defineField, defineType } from 'sanity'
+
+export const richImageListType = defineType({
+  name: 'richImageList',
+  title: 'Rich Image List',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'items',
+      title: 'Items',
+      type: 'array',
+      of: [
+        {
+          type: 'richImage',
+        },
+      ],
+    }),
+  ],
+  preview: {
+    select: {
+      richImages: 'items',
+    },
+    prepare: ({ richImages }) => ({
+      title: richImages
+        ? `${richImages.length} rich image${richImages.length === 1 ? '' : 's'}`
+        : 'empty',
+    }),
+  },
+})

--- a/schemaTypes/objects/richImageType.ts
+++ b/schemaTypes/objects/richImageType.ts
@@ -1,0 +1,28 @@
+import { defineField, defineType } from 'sanity'
+
+export const richImageType = defineType({
+  name: 'richImage',
+  title: 'Rich Image',
+  type: 'image',
+  options: {
+    hotspot: true,
+  },
+  fields: [
+    defineField({
+      name: 'altText',
+      title: 'Alt Text',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'caption',
+      title: 'Caption',
+      type: 'string',
+    }),
+    defineField({
+      name: 'credits',
+      title: 'Credits',
+      type: 'string',
+    }),
+  ],
+})


### PR DESCRIPTION
## Background

We need to be able to show some pictures. It would be very boring if text and code are the only forms of content. Also, the image should support some metadata, like captions and alternative texts for accessibility.

## Solution

Created a rich image type. This is a Sanity image with three added fields that are pretty standard for any picture:
* alt text
* caption
* credits

Also enabled hotspot as it is a nice QOL feature from Sanity. To use this in articles I made a list type that can have many images.
