### PR TITLE
Add proper validation for typegen types

### DIFF
--- a/schemaTypes/objects/codeBlockListType.ts
+++ b/schemaTypes/objects/codeBlockListType.ts
@@ -1,4 +1,4 @@
-import { defineField, defineType } from 'sanity'
+import { defineField, defineType, validation } from 'sanity'
 
 export const codeBlockListType = defineType({
   name: 'codeBlockList',
@@ -10,8 +10,13 @@ export const codeBlockListType = defineType({
       title: 'Items',
       type: 'array',
       of: [
-        defineField({ name: 'codeBlock', title: 'Code block', type: 'code' }),
+        defineField({
+          name: 'codeBlock',
+          title: 'Code block',
+          type: 'code',
+        }),
       ],
+      validation: (Rule) => Rule.required(),
     },
   ],
   preview: {

--- a/schemaTypes/objects/richImageListType.ts
+++ b/schemaTypes/objects/richImageListType.ts
@@ -14,6 +14,7 @@ export const richImageListType = defineType({
           type: 'richImage',
         },
       ],
+      validation: (Rule) => Rule.required(),
     }),
   ],
   preview: {

--- a/schemaTypes/objects/textBlockListType.ts
+++ b/schemaTypes/objects/textBlockListType.ts
@@ -10,6 +10,7 @@ export const textBlockListType = defineType({
       title: 'Items',
       type: 'array',
       of: [{ type: 'textBlock' }],
+      validation: (Rule) => Rule.required(),
     }),
   ],
   preview: {

--- a/schemaTypes/objects/textBlockType.ts
+++ b/schemaTypes/objects/textBlockType.ts
@@ -10,6 +10,7 @@ export const textBlockType = defineType({
       title: 'Text',
       type: 'array',
       of: [{ type: 'block' }],
+      validation: (Rule) => Rule.required(),
     }),
   ],
 })


### PR DESCRIPTION
## Background

To get correct types for the frontend, we can use Sanity's TypeGen feature, where you extract the schema of your Sanity Studio, and then generate types from this schema. This though, will mostly end up nullable if you don't specify that you want enforcing rules, and have used proper validation for those types!

## Solution

Tested a bit, and found the fields that missed validation to be properly parsed in the frontend.
