### PR TITLE
Refactor into own Code Block type

### DIFF
--- a/schemaTypes/objects/codeBlockListType.ts
+++ b/schemaTypes/objects/codeBlockListType.ts
@@ -13,7 +13,7 @@ export const codeBlockListType = defineType({
         defineField({
           name: 'codeBlock',
           title: 'Code block',
-          type: 'code',
+          type: 'codeBlock',
         }),
       ],
       validation: (Rule) => Rule.required(),

--- a/schemaTypes/objects/codeBlockType.ts
+++ b/schemaTypes/objects/codeBlockType.ts
@@ -1,0 +1,19 @@
+import { defineField, defineType } from 'sanity'
+
+export const codeBlockType = defineType({
+  name: 'codeBlock',
+  title: 'Code Block',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'filename',
+      title: 'Filename',
+      type: 'string',
+    }),
+    defineField({
+      name: 'code',
+      title: 'Code',
+      type: 'code',
+    }),
+  ],
+})

--- a/schemaTypes/objects/index.ts
+++ b/schemaTypes/objects/index.ts
@@ -1,3 +1,4 @@
+export { codeBlockType } from './codeBlockType'
 export { codeBlockListType } from './codeBlockListType'
 export { richImageListType } from './richImageListType'
 export { richImageType } from './richImageType'


### PR DESCRIPTION
## Background

Using the code type out of the box means you can't add metadata to a specific code block. Not nice.

## Solution

Refactor into own codeBlock component. Added field for specifying a filename.
